### PR TITLE
Install missing headers and fix C++11 std::unordered_map use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,22 +79,22 @@ if(CARVE_SYSTEM_BOOST)
     set(CARVE_SYSTEM_BOOST OFF)
   endif(Boost_FOUND)
 endif(CARVE_SYSTEM_BOOST)
-  
+
 if(CARVE_BOOST_COLLECTIONS)
   set(HAVE_BOOST_UNORDERED_COLLECTIONS TRUE)
 
 else(CARVE_BOOST_COLLECTIONS)
   # attempt to work out which unordered collection implementation we can use
   try_compile(_HAVE_STD_UNORDERED_COLLECTIONS
-              ${CMAKE_BINARY_DIR} 
+              ${CMAKE_BINARY_DIR}
               "${carve_SOURCE_DIR}/cmake/test_std_unordered.cpp"
               OUTPUT_VARIABLE OUTPUT)
   try_compile(_HAVE_TR1_UNORDERED_COLLECTIONS
-              ${CMAKE_BINARY_DIR} 
+              ${CMAKE_BINARY_DIR}
               "${carve_SOURCE_DIR}/cmake/test_tr1_unordered.cpp"
               OUTPUT_VARIABLE OUTPUT)
   try_compile(_HAVE_LIBSTDCPP_UNORDERED_COLLECTIONS
-              ${CMAKE_BINARY_DIR} 
+              ${CMAKE_BINARY_DIR}
               "${carve_SOURCE_DIR}/cmake/test_libstdcpp_unordered.cpp"
               OUTPUT_VARIABLE OUTPUT)
 
@@ -134,20 +134,20 @@ if(CARVE_WITH_GUI)
       if(WIN32)
         add_definitions(-DGLEW_STATIC)
       endif(WIN32)
-      add_subdirectory(external/GLEW) 
+      add_subdirectory(external/GLEW)
     endif(GLEW_FOUND)
 
     if(WIN32)
       add_definitions(-DGLUI_NO_LIB_PRAGMA)
       add_definitions(-DGLUI_USE_STATIC_LIB)
     endif(WIN32)
-    add_subdirectory(external/GLUI) 
+    add_subdirectory(external/GLUI)
 
   endif(NOT OPENGL_FOUND)
 
 endif(CARVE_WITH_GUI)
 
-add_subdirectory(external/GLOOP) 
+add_subdirectory(external/GLOOP)
 
 if (CARVE_GTEST_TESTS)
   add_subdirectory(external/gtest-1.5.0)
@@ -161,13 +161,22 @@ add_definitions(-DCMAKE_BUILD)
 
 include_directories(${carve_BINARY_DIR}/include)
 
-add_subdirectory(lib) 
-add_subdirectory(include) 
-add_subdirectory(common) 
-add_subdirectory(src) 
-add_subdirectory(examples) 
-add_subdirectory(tests) 
+add_subdirectory(lib)
+add_subdirectory(include)
+add_subdirectory(common)
+add_subdirectory(src)
+add_subdirectory(examples)
+add_subdirectory(tests)
 
+install(
+  FILES
+    ${carve_BINARY_DIR}/include/carve/config.h
+    ${carve_SOURCE_DIR}/include/carve/gnu_cxx.h
+  DESTINATION
+    include/carve
+  COMPONENT
+    Devel
+)
 
 include(CTest)
 

--- a/include/carve/collection/unordered/std_impl.hpp
+++ b/include/carve/collection/unordered/std_impl.hpp
@@ -29,3 +29,19 @@
 #include <unordered_set>
 
 #undef UNORDERED_COLLECTIONS_SUPPORT_RESIZE
+
+namespace std {
+
+  template <typename A, typename B>
+  struct hash<std::pair<A, B> > : public std::unary_function<std::pair<A, B>, size_t> {
+    size_t operator()(const std::pair<A, B> &v) const {
+      std::size_t seed = 0;
+
+      seed ^= hash<A>()(v.first);
+      seed ^= hash<B>()(v.second) + (seed<<6) + (seed>>2);
+
+      return seed;
+    }
+  };
+
+}

--- a/include/carve/exact.hpp
+++ b/include/carve/exact.hpp
@@ -27,6 +27,7 @@
 
 #include <carve/carve.hpp>
 
+#include <algorithm>
 #include <vector>
 #include <numeric>
 
@@ -154,7 +155,7 @@ namespace carve {
           double half;
           double check, lastcheck;
           int every_other;
-  
+
           every_other = 1;
           half = 0.5;
           epsilon = 1.0;
@@ -174,7 +175,7 @@ namespace carve {
             check = 1.0 + epsilon;
           } while ((check != 1.0) && (check != lastcheck));
           splitter += 1.0;
-  
+
           /* Error bounds for orientation and incircle tests. */
           resulterrbound = (3.0 + 8.0 * epsilon) * epsilon;
           ccwerrboundA = (3.0 + 16.0 * epsilon) * epsilon;
@@ -704,7 +705,7 @@ namespace carve {
       sum_zeroelim(cdet, ddet, cddet);
 
       sum_zeroelim(abdet, cddet, det);
-  
+
       return det[det.size() - 1];
     }
 

--- a/include/carve/geom2d.hpp
+++ b/include/carve/geom2d.hpp
@@ -32,6 +32,8 @@
 
 #include <carve/geom.hpp>
 
+#include <algorithm>
+#include <cstddef>
 #include <vector>
 
 #include <math.h>
@@ -62,15 +64,15 @@ namespace carve {
 
     typedef std::vector<P2> P2Vector;
 
-    /** 
+    /**
      * \brief Return the orientation of c with respect to the ray defined by a->b.
      *
      * (Can be implemented exactly)
-     * 
-     * @param[in] a 
-     * @param[in] b 
-     * @param[in] c 
-     * 
+     *
+     * @param[in] a
+     * @param[in] b
+     * @param[in] c
+     *
      * @return positive, if c to the left of a->b.
      *         zero, if c is colinear with a->b.
      *         negative, if c to the right of a->b.
@@ -89,15 +91,15 @@ namespace carve {
     }
 #endif
 
-    /** 
+    /**
      * \brief Determine whether p is internal to the anticlockwise
      *        angle abc, where b is the apex of the angle.
      *
-     * @param[in] a 
-     * @param[in] b 
-     * @param[in] c 
-     * @param[in] p 
-     * 
+     * @param[in] a
+     * @param[in] b
+     * @param[in] c
+     * @param[in] p
+     *
      * @return true, if p is contained in the anticlockwise angle from
      *               b->a to b->c. Reflex angles contain p if p lies
      *               on b->a or on b->c. Acute angles do not contain p
@@ -118,14 +120,14 @@ namespace carve {
       }
     }
 
-    /** 
+    /**
      * \brief Determine whether p is internal to the anticlockwise
      *        angle ac, with apex at (0,0).
      *
-     * @param[in] a 
-     * @param[in] c 
-     * @param[in] p 
-     * 
+     * @param[in] a
+     * @param[in] c
+     * @param[in] p
+     *
      * @return true, if p is contained in a0c.
      */
     inline bool internalToAngle(const P2 &a,

--- a/include/carve/intersection.hpp
+++ b/include/carve/intersection.hpp
@@ -32,10 +32,10 @@
 namespace carve {
   namespace csg {
 
-    /** 
+    /**
      * \class Intersections
      * \brief Storage for computed intersections between vertices, edges and faces.
-     * 
+     *
      */
     struct Intersections : public std::unordered_map<IObj, IObjVMapSmall, IObj_hash> {
       typedef carve::mesh::MeshSet<3>::vertex_t vertex_t;
@@ -47,9 +47,9 @@ namespace carve {
       ~Intersections() {
       }
 
-      /** 
+      /**
        * \brief Record the position of intersection between a pair of intersection objects.
-       * 
+       *
        * @param a The first intersecting object.
        * @param b The second intersecting object.
        * @param p The point of intersection.
@@ -60,19 +60,19 @@ namespace carve {
         (*this)[b][a] = p;
       }
 
-      /** 
+      /**
        * \brief Test whether vertex \a v intersects face \a f.
-       * 
+       *
        * @param v The vertex to test.
        * @param f The face to test.
-       * 
+       *
        * @return true, if \a v intersects \a f.
        */
       bool intersectsFace(vertex_t *v, face_t *f) const;
 
-      /** 
+      /**
        * \brief Collect sets of vertices, edges and faces that intersect \a obj
-       * 
+       *
        * @param[in] obj The intersection object to search for intersections.
        * @param[out] collect_v A vector of vertices intersecting \a obj.
        * @param[out] collect_e A vector of edges intersecting \a obj.
@@ -84,12 +84,12 @@ namespace carve {
                    std::vector<face_t *> *collect_f) const;
 
 
-      /** 
+      /**
        * \brief Determine whether two intersection objects intersect.
-       * 
+       *
        * @param a The first intersection object.
        * @param b The second intersection object.
-       * 
+       *
        * @return true, if \a a and \a b intersect.
        */
       bool intersectsExactly(const IObj &a, const IObj &b) {
@@ -98,12 +98,12 @@ namespace carve {
         return i->second.find(b) != i->second.end();
       }
 
-      /** 
+      /**
        * \brief Determine whether an intersection object intersects a vertex.
-       * 
+       *
        * @param a The intersection object.
        * @param v The vertex.
-       * 
+       *
        * @return true, if \a a and \a v intersect.
        */
       bool intersects(const IObj &a, vertex_t *v) {
@@ -113,19 +113,23 @@ namespace carve {
         return false;
       }
 
-      /** 
+      /**
        * \brief Determine whether an intersection object intersects an edge.
-       * 
+       *
        * @param a The intersection object.
        * @param e The edge.
-       * 
+       *
        * @return true, if \a a and \a e intersect (either on the edge,
        *         or at either endpoint).
        */
       bool intersects(const IObj &a, edge_t *e) {
         Intersections::const_iterator i = find(a);
         if (i == end()) return false;
+#ifdef HAVE_STD_UNORDERED_COLLECTIONS
+        for (super::mapped_type::const_iterator j = i->second.begin(); j != i->second.end(); ++j) {
+#else
         for (super::data_type::const_iterator j = i->second.begin(); j != i->second.end(); ++j) {
+#endif
           const IObj &obj = j->first;
           switch (obj.obtype) {
           case IObj::OBTYPE_VERTEX:
@@ -141,12 +145,12 @@ namespace carve {
         return false;
       }
 
-      /** 
+      /**
        * \brief Determine whether an intersection object intersects a face.
-       * 
+       *
        * @param a The intersection object.
        * @param f The face.
-       * 
+       *
        * @return true, if \a a and \a f intersect (either on the face,
        *         or at any associated edge or vertex).
        */
@@ -163,12 +167,12 @@ namespace carve {
         return false;
       }
 
-      /** 
+      /**
        * \brief Determine whether an edge intersects another edge.
-       * 
+       *
        * @param e The edge.
        * @param f The face.
-       * 
+       *
        * @return true, if \a e and \a f intersect.
        */
       bool intersects(edge_t *e1, edge_t *e2) {
@@ -176,12 +180,12 @@ namespace carve {
         return false;
       }
 
-      /** 
+      /**
        * \brief Determine whether an edge intersects a face.
-       * 
+       *
        * @param e The edge.
        * @param f The face.
-       * 
+       *
        * @return true, if \a e and \a f intersect.
        */
       bool intersects(edge_t *e, face_t *f) {
@@ -189,9 +193,9 @@ namespace carve {
         return false;
       }
 
-      /** 
+      /**
        * \brief Determine the faces intersected by an edge.
-       * 
+       *
        * @tparam face_set_t A collection type holding face_t *
        * @param[in] e The edge.
        * @param[out] f The resulting set of faces.
@@ -213,9 +217,9 @@ namespace carve {
         f.insert(intersected_faces.begin(), intersected_faces.end());
       }
 
-      /** 
+      /**
        * \brief Determine the faces intersected by a vertex.
-       * 
+       *
        * @tparam face_set_t A collection type holding face_t *
        * @param[in] v The vertex.
        * @param[out] f The resulting set of faces.
@@ -237,9 +241,9 @@ namespace carve {
         f.insert(intersected_faces.begin(), intersected_faces.end());
       }
 
-      /** 
+      /**
        * \brief Collect the set of faces that contain all vertices in \a verts.
-       * 
+       *
        * @tparam vertex_set_t A collection type holding vertex_t *
        * @tparam face_set_t A collection type holding face_t *
        * @param[in] verts A set of vertices.

--- a/include/carve/mesh_impl.hpp
+++ b/include/carve/mesh_impl.hpp
@@ -30,6 +30,7 @@
 #include <carve/djset.hpp>
 
 #include <iostream>
+#include <cstddef>
 #include <deque>
 
 namespace carve {
@@ -553,7 +554,7 @@ namespace carve {
         for (size_t i = 0; i < set_size.size(); ++i) {
           mesh_faces[i].reserve(set_size[i]);
         }
-      
+
         for (iter_t i = begin; i != end; ++i) {
           face_t *face = *i;
           mesh_faces[index_set[face->id]].push_back(face);

--- a/include/carve/mesh_simplify.hpp
+++ b/include/carve/mesh_simplify.hpp
@@ -130,7 +130,7 @@ namespace carve {
           return e->edge->prev->vert == e->edge->rev->prev->vert;
         }
 
-        bool flippable_DotProd(const EdgeInfo *e) const { 
+        bool flippable_DotProd(const EdgeInfo *e) const {
           using carve::geom::dot;
           using carve::geom::cross;
 
@@ -476,7 +476,7 @@ namespace carve {
               tri_b[0] = fb->edge->vert->v;
               tri_b[1] = fb->edge->next->vert->v;
               tri_b[2] = fb->edge->next->next->vert->v;
-              
+
               if (carve::geom::triangle_intersection_exact(tri_a, tri_b) == carve::geom::TR_TYPE_INT) {
                 ++r;
               }
@@ -765,7 +765,7 @@ namespace carve {
           vector_t aabb_min, aabb_max;
           assign_op(aabb_min, v1->v, v2->v, carve::util::min_functor());
           assign_op(aabb_max, v1->v, v2->v, carve::util::max_functor());
-          
+
           for (size_t i = 0; i < v1_incident.size(); ++i) {
             assign_op(aabb_min, aabb_min, v1_incident[i]->edge->v1()->v, carve::util::min_functor());
             assign_op(aabb_max, aabb_max, v1_incident[i]->edge->v1()->v, carve::util::max_functor());
@@ -1285,7 +1285,11 @@ namespace carve {
             open.erase(open.begin());
             face_set.insert(curr);
             axes |= axis_influence[curr];
+#ifdef HAVE_STD_UNORDERED_COLLECTIONS
+            for (interaction_graph_t::mapped_type::iterator i = interacting_faces[curr].begin(), e = interacting_faces[curr].end(); i != e; ++i) {
+#else
             for (interaction_graph_t::data_type::iterator i = interacting_faces[curr].begin(), e = interacting_faces[curr].end(); i != e; ++i) {
+#endif
               face_t *f = *i;
               if (face_set.find(f) != face_set.end()) continue;
               open.insert(f);
@@ -1323,7 +1327,7 @@ namespace carve {
           if (grid) {
             carve::geom::vector<3> v_best = vert->v;
             double d_best = 0.0;
-            
+
             for (size_t axes = 0; axes < 8; ++axes) {
               carve::geom::vector<3> v = vert->v;
               for (size_t N = 0; N < 3; ++N) {
@@ -1398,8 +1402,8 @@ namespace carve {
         return modifications;
       }
 
-      
-      
+
+
       size_t removeFins(mesh_t *mesh) {
         size_t n_removed = 0;
         for (size_t i = 0; i < mesh->faces.size(); ++i) {

--- a/include/carve/vector.hpp
+++ b/include/carve/vector.hpp
@@ -31,6 +31,7 @@
 #include <carve/geom.hpp>
 #include <carve/geom3d.hpp>
 
+#include <algorithm>
 #include <sstream>
 
 #include <math.h>
@@ -64,7 +65,7 @@ namespace carve {
     };
 
 
-  
+
     struct vec_adapt_pair_first {
       template<typename pair_t> const Vector &operator()(const pair_t &v) const { return v.first; }
       template<typename pair_t> Vector &operator()(pair_t &v) const { return v.first; }


### PR DESCRIPTION
- add `gnu_cxx.h` and `config.h` when running make install
- implement `std::hash` for `std::unordered_map` use
