### PR TITLE
MSVC2013 compatibility, sign warnings, headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmake_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-cmake_build
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(OPENMP_FOUND)
 endif()
 
 if(CARVE_WITH_GUI)
+  set(OpenGL_GL_PREFERENCE GLVND)
   find_package(OpenGL)
   find_package(GLUT)
   find_package(GLEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,10 @@ if (MSVC)
     # In hermetic build environments, tests may not have access to MS runtime
     # DLLs, so this replaces /MD (CRT libraries in DLLs) with /MT (static CRT
     # libraries).
-    string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
+  #  string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
     # We prefer more strict warning checking for building Google Test.
     # Replaces /W3 with /W4 in defaults.
-    string(REPLACE "/W3" "-W4" ${flag_var} "${${flag_var}}")
+  #  string(REPLACE "/W3" "-W4" ${flag_var} "${${flag_var}}")
   endforeach()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(CARVE_DEBUG                       "Compile in debug code"                
 option(CARVE_DEBUG_WRITE_PLY_DATA        "Write geometry output during debug"                OFF)
 option(CARVE_USE_EXACT_PREDICATES        "Use Shewchuk's exact predicates, where possible"   OFF)
 option(CARVE_INTERSECT_GLU_TRIANGULATOR  "Include support for GLU triangulator in intersect" OFF)
-option(CARVE_GTEST_TESTS                 "Complie gtest, and dependent tests"                ON)
+option(CARVE_GTEST_TESTS                 "Compile gtest, and dependent tests"                ON)
 
 if (MSVC)
   # For MSVC, CMake sets certain flags to defaults we want to override.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-This fork of carve contains fixes to allow static compilation for
-* Windows MSVC2013 Express compiler x64
-* Linux Ubuntu GNU g++ 7.3.0 with boost x64
+This fork of carve contains fixes to allow static library compilation for
+* Windows MSVC2013 (express) & MSVC2019 (community) x64 compilers 
+* Linux Ubuntu GNU g++ x64
 
 ## Basic build instructions
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+
+This fork of carve contains fixes to allow static compilation for
+* Windows MSVC2013 Express compiler x64
+* Linux Ubuntu GNU g++ 7.3.0 with boost x64
+
+## Basic build instructions
+
+* Use CMake Gui on both platforms, disable dev warning (Options menu)
+* Enable only CARVE_USE_EXACT_PREDICATES
+* Set "Where to build" ../carve/cmake_build
+* Windows MSVC2013: Build using carve/cmake_build/carve.sln
+   * Static libs under cmake_build/lib/Release and cmake_build/lib/Debug
+* Linux: Build with makefile under carve/cmake_build
+   * Static lib under cmake_build/lib
+
+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This fork of carve contains fixes to allow static library compilation for
 ## Linux command line build with cmake
 
 $ cd carve
+
 $ cmake -B build -DBUILD_TESTING:BOOL="0" -DCARVE_USE_EXACT_PREDICATES:BOOL="1" -DCARVE_GTEST_TESTS:BOOL="0" -DCARVE_WITH_GUI:BOOL="0" -DBUILD_SHARED_LIBS:BOOL="0"
+
 $ cd build
+
 $ make

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@ This fork of carve contains fixes to allow static compilation for
 
 * Use CMake Gui on both platforms, disable dev warning (Options menu)
 * Enable only CARVE_USE_EXACT_PREDICATES
-* Set "Where to build" ../carve/cmake_build
-* Windows MSVC2013: Build using carve/cmake_build/carve.sln
-   * Static libs under cmake_build/lib/Release and cmake_build/lib/Debug
-* Linux: Build with makefile under carve/cmake_build
-   * Static lib under cmake_build/lib
+* Set "Where to build" ../carve/build
+* Windows MSVC2013: Build using carve/build/carve.sln
+   * Static libs under build/lib/Release and build/lib/Debug
+* Linux: Build with makefile under carve/build
+   * Static lib under build/lib
 
+## Linux command line build with cmake
 
+$ cd carve
+$ cmake -B build -DBUILD_TESTING:BOOL="0" -DCARVE_USE_EXACT_PREDICATES:BOOL="1" -DCARVE_GTEST_TESTS:BOOL="0" -DCARVE_WITH_GUI:BOOL="0" -DBUILD_SHARED_LIBS:BOOL="0"
+$ cd build
+$ make

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+echo building the carve library for Linux...
+# by Carsten Arnholm, December 2020
+# 
+# Requirements
+#   1) cmake must be installed and defined in system PATH
+# 
+# Output is found in "build" folder 
+#    only carve static library is built
+#
+# Using the library:
+#    include paths:  
+#       carve/include
+#       carve/build/include
+#       
+#    lib path:
+#       carve/build/lib
+#
+cmake -B build \
+     -DBUILD_TESTING:BOOL="0" \
+     -DCARVE_USE_EXACT_PREDICATES:BOOL="1" \
+     -DBUILD_SHARED_LIBS:BOOL="0"  \
+     -DCARVE_GTEST_TESTS:BOOL="0" \
+     -DCARVE_WITH_GUI:BOOL="0" \
+     -DBUILD_SHARED_LIBS:BOOL="0"
+#
+cd build
+make carve
+ls -l ./lib/*.a
+echo Carve build script ended

--- a/build_windows_msvc.cmd
+++ b/build_windows_msvc.cmd
@@ -1,0 +1,32 @@
+@echo off
+echo building the carve library for MSVC...
+REM by Carsten Arnholm, December 2020
+REM 
+REM Requirements
+REM   1) Must be executed from "MSVC Developer Command Prompt"
+REM   2) cmake must be installed and defined in system PATH
+REM 
+REM Output is found in "build" folder 
+REM    only carve static library is built
+REM
+REM Using the library
+REM    include paths:  
+REM       carve/include
+REM       
+REM    lib path:
+REM       carve/build/lib/Release     (for release builds)
+REM       carve/build/lib/Debug       (for debug builds)
+REM
+cmake -B build ^
+     -DBUILD_TESTING:BOOL="0" ^
+     -DCARVE_USE_EXACT_PREDICATES:BOOL="1" ^
+     -DBUILD_SHARED_LIBS:BOOL="0"  ^
+     -DCARVE_GTEST_TESTS:BOOL="0" ^
+     -DCARVE_WITH_GUI:BOOL="0" ^
+     -DBUILD_SHARED_LIBS:BOOL="0"
+REM
+cd build
+msbuild carve.sln -target:carve /p:Platform="x64" /p:Configuration=Release /m
+msbuild carve.sln -target:carve /p:Platform="x64" /p:Configuration=Debug /m
+dir .\lib\Debug,.\lib\release
+echo Carve build script ended

--- a/common/write_ply.cpp
+++ b/common/write_ply.cpp
@@ -51,7 +51,7 @@ struct vertex : public vertex_base {
   int i;
   vertex(const container_t& _cnt) : cnt(_cnt), i(-1) {}
   void next() override { ++i; }
-  int length() override { return cnt.size(); }
+  int length() override { return static_cast<int>(cnt.size()); }
   const carve::geom3d::Vector& curr() const override { return cnt[i].v; }
 };
 
@@ -74,7 +74,7 @@ struct mesh_face : public gloop::stream::null_writer {
     std::copy(poly->faceBegin(), poly->faceEnd(), std::back_inserter(faces));
   }
   void next() override { ++i; }
-  int length() override { return faces.size(); }
+  int length() override { return static_cast<int>(faces.size()); }
   const carve::mesh::MeshSet<3>::face_t* curr() const { return faces[i]; }
 };
 
@@ -91,7 +91,7 @@ struct mesh_face_idx : public gloop::stream::writer<size_t> {
     f = r.curr();
     i = f->begin();
   }
-  int length() override { return f->nVertices(); }
+  int length() override { return static_cast<int>(f->nVertices()); }
 
   bool isList() override { return true; }
   gloop::stream::Type dataType() override { return data_type; }
@@ -108,7 +108,7 @@ struct face : public gloop::stream::null_writer {
   int i;
   face(const carve::poly::Polyhedron* _poly) : poly(_poly), i(-1) {}
   void next() override { ++i; }
-  int length() override { return poly->faces.size(); }
+  int length() override { return static_cast<int>(poly->faces.size()); }
   const carve::poly::Face<3>* curr() const { return &poly->faces[i]; }
 };
 
@@ -129,7 +129,7 @@ struct face_idx : public gloop::stream::writer<size_t> {
     f = r.curr();
     i = 0;
   }
-  int length() override { return f->nVertices(); }
+  int length() override { return static_cast<int>(f->nVertices()); }
 
   bool isList() override { return true; }
   gloop::stream::Type dataType() override { return data_type; }
@@ -152,7 +152,7 @@ struct lineset : public gloop::stream::null_writer {
     c = n;
     ++n;
   }
-  int length() override { return polyline->lines.size(); }
+  int length() override { return static_cast<int>(polyline->lines.size()); }
   const carve::line::Polyline* curr() const { return *c; }
 };
 
@@ -183,7 +183,7 @@ struct line_vi : public gloop::stream::writer<size_t> {
     l = ls.curr();
     i = 0;
   }
-  int length() override { return l->vertexCount(); }
+  int length() override { return static_cast<int>(l->vertexCount()); }
   size_t value() override {
     return ls.polyline->vertexToIndex_fast(l->vertex(i++));
   }
@@ -208,8 +208,8 @@ void setup(gloop::stream::model_writer& file,
   file.addWriter("polyhedron.face", fi);
   file.addWriter("polyhedron.face.vertex_indices",
                  new mesh_face_idx(*fi, gloop::stream::smallest_type(
-                                            poly->vertex_storage.size()),
-                                   face_max));
+				 static_cast<uint32_t>(poly->vertex_storage.size())),
+											static_cast<int>(face_max)));
 }
 
 void setup(gloop::stream::model_writer& file,
@@ -230,8 +230,8 @@ void setup(gloop::stream::model_writer& file,
   file.addWriter("polyhedron.face", fi);
   file.addWriter(
       "polyhedron.face.vertex_indices",
-      new face_idx(*fi, gloop::stream::smallest_type(poly->vertices.size()),
-                   face_max));
+	  new face_idx(*fi, gloop::stream::smallest_type(static_cast<uint32_t>(poly->vertices.size())),
+	  static_cast<int>(face_max)));
 }
 
 void setup(gloop::stream::model_writer& file,
@@ -256,8 +256,8 @@ void setup(gloop::stream::model_writer& file,
   file.addWriter("polyline.polyline.closed", new line_closed(*pi));
   file.addWriter(
       "polyline.polyline.vertex_indices",
-      new line_vi(*pi, gloop::stream::smallest_type(lines->vertices.size()),
-                  line_max));
+	  new line_vi(*pi, gloop::stream::smallest_type(static_cast<uint32_t>(lines->vertices.size())),
+	  static_cast<int>(line_max)));
 }
 
 void setup(gloop::stream::model_writer& file,

--- a/external/GLOOP/include/gloop/model/stream.hpp
+++ b/external/GLOOP/include/gloop/model/stream.hpp
@@ -32,7 +32,7 @@
 #include <gloop/exceptions.hpp>
 #include <gloop/ref.hpp>
 
-#ifdef WIN32
+#if defined(WIN32) && defined(_MSC_VER) && _MSC_VER < 1800
 
 typedef char int8_t;
 typedef short int16_t;
@@ -153,7 +153,7 @@ namespace gloop {
     void send_sequence(reader_base *rd, size_t n, iter_t begin, iter_t end) {
       if (rd) {
         rd->begin();
-        rd->length(n);
+        rd->length(static_cast<int>(n));
         while (begin != end) {
           rd->next();
           rd->_val(*begin++);

--- a/external/GLOOP/src/model/obj_format.cpp
+++ b/external/GLOOP/src/model/obj_format.cpp
@@ -33,7 +33,7 @@
 #include <iostream>
 #include <iomanip>
 #include <iterator>
-
+#include <algorithm>
 
 namespace gloop {
   namespace obj {
@@ -101,7 +101,7 @@ namespace gloop {
       for (size_t i = 0; i < std::min(rd_count, r1.size()); ++i) {
         if (v_rd[i] && r1[i].size()) {
           v_rd[i]->begin();
-          v_rd[i]->length(blocks.size());
+          v_rd[i]->length(static_cast<int>(blocks.size()));
         }
       }
 
@@ -317,19 +317,19 @@ namespace {
         uint32_t idx;
         v_prop->wt->next();
         v_prop->wt->_val(idx);
-        idx += v_base;
+		idx += static_cast<uint32_t>(v_base);
         s << idx;
         if (vt_prop || vn_prop) s << "/";
         if (vt_prop) {
           vt_prop->wt->next();
           vt_prop->wt->_val(idx);
-          idx += vt_base;
+		  idx += static_cast<uint32_t>(vt_base);
           s << idx;
         }
         if (vn_prop) {
           vn_prop->wt->next();
           vn_prop->wt->_val(idx);
-          idx += vn_base;
+		  idx += static_cast<uint32_t>(vn_base);
           s << "/" << idx;
         }
       }

--- a/external/GLOOP/src/model/ply_format.cpp
+++ b/external/GLOOP/src/model/ply_format.cpp
@@ -34,7 +34,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#ifdef WIN32
+#if defined(WIN32) && defined(_MSC_VER) && _MSC_VER < 1800
 
 typedef char int8_t;
 typedef short int16_t;
@@ -403,7 +403,7 @@ namespace {
         in.seekg(len * sz, std::ios_base::cur);
       } else {
         rd->begin();
-        rd->length(len);
+        rd->length(static_cast<int>(len));
         for (size_t i = 0; i < len; ++i) {
           rd->next();
           in.read(buf, sz);
@@ -426,7 +426,7 @@ namespace {
       }
       if (rd != NULL) {
         rd->begin();
-        rd->length(len);
+        rd->length(static_cast<int>(len));
         for (size_t i = 0; i < len; ++i) {
           rd->next();
           if (!prop_read(in, type, rd)) {
@@ -503,7 +503,7 @@ namespace {
         in >> s_count;
         if (!in.fail()) {
           name = s_name;
-          count = s_count;
+          count = static_cast<int>(s_count);
         }
       }
     }

--- a/external/GLOOP/src/model/vtk_format.cpp
+++ b/external/GLOOP/src/model/vtk_format.cpp
@@ -86,7 +86,7 @@ namespace gloop {
       stream::reader_base *z_rd = findReader(base, "vertex", "z");
       if (e_rd) {
         e_rd->begin();
-        e_rd->length(point_data.size());
+        e_rd->length(static_cast<int>(point_data.size()));
       }
       // std::cerr << "emitting " << point_data.size() << " points" << std::endl;
       for (size_t i = 0; i < point_data.size(); ++i) {
@@ -184,7 +184,7 @@ namespace gloop {
 
             if (e_rd) {
               e_rd->begin();
-              e_rd->length(num);
+              e_rd->length(static_cast<int>(num));
             }
 
             size_t x = 0;
@@ -226,7 +226,7 @@ namespace gloop {
 
             if (e_rd) {
               e_rd->begin();
-              e_rd->length(num);
+              e_rd->length(static_cast<int>(num));
             }
 
             size_t x = 0;

--- a/include/carve/aabb_impl.hpp
+++ b/include/carve/aabb_impl.hpp
@@ -32,6 +32,7 @@
 #include <carve/geom.hpp>
 
 #include <vector>
+#include <algorithm>
 
 namespace carve {
 namespace geom {

--- a/include/carve/csg_triangulator.hpp
+++ b/include/carve/csg_triangulator.hpp
@@ -136,7 +136,7 @@ class CarveTriangulationImprover : public csg::CSG::Hook {
           } else {
             v = (*j).second;
           }
-          tri.v[i.idx()] = v;
+          tri.v[i.idx()] = static_cast<unsigned int>(v);
         }
         result.push_back(tri);
         delete face;

--- a/include/carve/exact.hpp
+++ b/include/carve/exact.hpp
@@ -382,7 +382,7 @@ static inline void prod_2_1(const double* a, const double* b, double* r) {
   double t3[2];
   op<1, 1>::add(t1 + 1, t2, t3);
   r[1] = t3[0];
-  double t4[2];
+//  double t4[2];
   op<1, 1>::add_fast(t2 + 1, t3 + 1, r + 2);
 }
 
@@ -510,7 +510,7 @@ static inline void square_2(const double* a, double* r) {
   r[1] = t4[0];
   double t5[2];
   square(a[1], t5);
-  double t6[4];
+//  double t6[4];
   op<2, 2>::add(t5, t4 + 1, r + 2);
 }
 }  // namespace detail
@@ -518,7 +518,7 @@ static inline void square_2(const double* a, double* r) {
 void exact_t::compress() {
   double sum[2];
 
-  int j = size() - 1;
+  size_t j = size() - 1;
   double Q = (*this)[j];
   for (int i = (int)size() - 2; i >= 0; --i) {
     detail::op<1, 1>::add_fast(&Q, &(*this)[i], sum);
@@ -530,7 +530,7 @@ void exact_t::compress() {
     }
   }
   int j2 = 0;
-  for (int i = j + 1; i < (int)size(); ++i) {
+  for (size_t i = j + 1; i < size(); ++i) {
     detail::op<1, 1>::add_fast(&(*this)[i], &Q, sum);
     if (sum[0] != 0) {
       (*this)[j2++] = sum[0];

--- a/include/carve/geom2d.hpp
+++ b/include/carve/geom2d.hpp
@@ -32,7 +32,7 @@
 #include <carve/geom.hpp>
 
 #include <vector>
-
+#include <algorithm>
 #include <math.h>
 
 #if defined(CARVE_DEBUG)

--- a/include/carve/input.hpp
+++ b/include/carve/input.hpp
@@ -138,7 +138,7 @@ struct PolyhedronData : public VertexData {
   void addFace(Iter begin, Iter end) {
     size_t n = std::distance(begin, end);
     faceIndices.reserve(faceIndices.size() + n + 1);
-    faceIndices.push_back(n);
+    faceIndices.push_back(static_cast<int>(n));
     std::copy(begin, end, std::back_inserter(faceIndices));
     ++faceCount;
   }

--- a/include/carve/mesh.hpp
+++ b/include/carve/mesh.hpp
@@ -310,7 +310,8 @@ class Face : public tagable {
         unproject(nullptr) {}
 
   Face(const Face& other)
-      : edge(nullptr),
+      : tagable(other),
+        edge(nullptr),
         n_edges(other.n_edges),
         mesh(nullptr),
         id(other.id),
@@ -326,10 +327,10 @@ class Face : public tagable {
   typedef detail::list_iter_t<const Edge<ndim> > const_edge_iter_t;
 
   edge_iter_t begin() { return edge_iter_t(edge, 0); }
-  edge_iter_t end() { return edge_iter_t(edge, n_edges); }
+  edge_iter_t end() { return edge_iter_t(edge, static_cast<int>(n_edges)); }
 
   const_edge_iter_t begin() const { return const_edge_iter_t(edge, 0); }
-  const_edge_iter_t end() const { return const_edge_iter_t(edge, n_edges); }
+  const_edge_iter_t end() const { return const_edge_iter_t(edge, static_cast<int>(n_edges)); }
 
   bool containsPoint(const vector_t& p) const;
   bool containsPointInProjection(const vector_t& p) const;

--- a/include/carve/mesh_impl.hpp
+++ b/include/carve/mesh_impl.hpp
@@ -438,7 +438,7 @@ typename Face<ndim>::vector_t Face<ndim>::centroid() const {
     v += e->vert->v;
     e = e->next;
   } while (e != edge);
-  v /= n_edges;
+  v /= static_cast<double>(n_edges);
   return v;
 }
 

--- a/include/carve/mesh_simplify.hpp
+++ b/include/carve/mesh_simplify.hpp
@@ -38,8 +38,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "write_ply.hpp"
+#include <functional>
 
 namespace carve {
 namespace mesh {
@@ -388,7 +387,7 @@ class MeshSimplifier {
       }
     }
 
-    return ints.size();
+    return static_cast<int>(ints.size());
   }
 
   int countIntersections(const vertex_t* v1, const vertex_t* v2,
@@ -1049,11 +1048,11 @@ class MeshSimplifier {
   }
 
   double minimize(carve::geom::vector<3>& vert,
-                  const std::list<carve::geom::plane<3> >& planes, int axis) {
+                  const std::list<carve::geom::plane<3> >& planes, unsigned axis) {
     double num = 0.0;
     double den = 0.0;
-    int a1 = (axis + 1) % 3;
-    int a2 = (axis + 2) % 3;
+    unsigned a1 = (axis + 1) % 3;
+    unsigned a2 = (axis + 2) % 3;
     for (std::list<carve::geom::plane<3> >::const_iterator i = planes.begin();
          i != planes.end(); ++i) {
       const carve::geom::vector<3>& N = (*i).N;
@@ -1311,7 +1310,7 @@ class MeshSimplifier {
       }
 
       double d = summedError(vert->v, planes);
-      for (size_t N = 0;; N = (N + 1) % 3) {
+      for (unsigned N = 0;; N = (N + 1) % 3) {
         if (constraint & (1 << N)) {
           continue;
         }
@@ -1333,7 +1332,7 @@ class MeshSimplifier {
             if (constraint & (1 << N)) {
               continue;
             }
-            if (axes & (1 << N)) {
+            if (axes & (1ULL << N)) {
               v.v[N] = ceil(v.v[N] / grid) * grid;
             } else {
               v.v[N] = floor(v.v[N] / grid) * grid;
@@ -1462,8 +1461,8 @@ class MeshSimplifier {
           heap() {
       for (size_t i = 0; i < (1 << 3); ++i) {
         vector_t t = origin;
-        for (size_t j = 0; j < 3; ++j) {
-          if (i & (1U << j)) {
+        for (unsigned j = 0; j < 3; ++j) {
+          if (i & (1ULL << j)) {
             t[j] = ceil(t[j] * rounding_fac) / rounding_fac;
           } else {
             t[j] = floor(t[j] * rounding_fac) / rounding_fac;

--- a/include/carve/polyhedron_impl.hpp
+++ b/include/carve/polyhedron_impl.hpp
@@ -256,7 +256,7 @@ int Polyhedron::vertexManifolds(const vertex_t* v, T result) const {
   }
 
   std::copy(em.begin(), em.end(), result);
-  return em.size();
+  return static_cast<int>(em.size());
 }
 
 template <typename T>

--- a/include/carve/polyline_iter.hpp
+++ b/include/carve/polyline_iter.hpp
@@ -69,7 +69,7 @@ struct polyline_vertex_iter
   }
 
   Vertex* operator*() const {
-    CARVE_ASSERT(idx >= 0 && idx < base->vertexCount());
+    CARVE_ASSERT(idx >= 0 && idx < static_cast<ssize_t>(base->vertexCount()));
     return base->vertex((size_t)idx);
   }
 };
@@ -139,7 +139,7 @@ struct polyline_vertex_const_iter
   }
 
   const Vertex* operator*() const {
-    CARVE_ASSERT(idx >= 0 && idx < base->vertexCount());
+    CARVE_ASSERT(idx >= 0 && idx < static_cast<ssize_t>(base->vertexCount()));
     return base->vertex((size_t)idx);
   }
 };
@@ -217,7 +217,7 @@ struct polyline_edge_iter
   }
 
   PolylineEdge* operator*() const {
-    CARVE_ASSERT(idx >= 0 && idx < base->edgeCount());
+    CARVE_ASSERT(idx >= 0 && idx < static_cast<ssize_t>(base->edgeCount()));
     return base->edge((size_t)idx);
   }
 };
@@ -287,7 +287,7 @@ struct polyline_edge_const_iter
   }
 
   const PolylineEdge* operator*() const {
-    CARVE_ASSERT(idx >= 0 && idx < base->edgeCount());
+    CARVE_ASSERT(idx >= 0 && idx < static_cast<ssize_t>(base->edgeCount()));
     return base->edge((size_t)idx);
   }
 };

--- a/include/carve/rtree.hpp
+++ b/include/carve/rtree.hpp
@@ -194,10 +194,10 @@ struct RTreeNode {
     aabb_cmp_mid(size_t _dim) : dim(_dim) {}
 
     bool operator()(const node_t* a, const node_t* b) {
-      return a->bbox.mid(dim) < b->bbox.mid(dim);
+      return a->bbox.mid(static_cast<unsigned int>(dim)) < b->bbox.mid(static_cast<unsigned int>(dim));
     }
     bool operator()(const data_aabb_t& a, const data_aabb_t& b) {
-      return a.bbox.mid(dim) < b.bbox.mid(dim);
+      return a.bbox.mid(static_cast<unsigned int>(dim)) < b.bbox.mid(static_cast<unsigned int>(dim));
     }
   };
 
@@ -257,7 +257,7 @@ struct RTreeNode {
     const size_t N = std::distance(begin, end);
 
     size_t dim = ndim;
-    double r_best = N + 1;
+    double r_best = static_cast<double>(N + 1);
 
     // find the sparsest remaining dimension to partition by.
     for (size_t i = 0; i < ndim; ++i) {

--- a/include/carve/vector.hpp
+++ b/include/carve/vector.hpp
@@ -31,7 +31,7 @@
 #include <carve/math_constants.hpp>
 
 #include <sstream>
-
+#include <algorithm>
 #include <math.h>
 
 namespace carve {

--- a/include/carve/win32.h
+++ b/include/carve/win32.h
@@ -21,7 +21,12 @@ inline long random() {
 }
 
 #if defined(_MSC_VER)
+#if _MSC_VER < 1800
 #  include <carve/cbrt.h>
+#else
+#  include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 
 #if _MSC_VER < 1300
 // intptr_t is an integer type that is big enough to hold a pointer

--- a/lib/intersect.cpp
+++ b/lib/intersect.cpp
@@ -1385,12 +1385,12 @@ void carve::csg::CSG::calc(meshset_t* a, const face_rtree_t* a_rtree,
 
 #if defined(CARVE_DEBUG_WRITE_PLY_DATA)
   {
-    std::auto_ptr<carve::mesh::MeshSet<3> > poly(
+    std::unique_ptr<carve::mesh::MeshSet<3> > poly(
         faceLoopsToPolyhedron(a_face_loops));
     writePLY("/tmp/a_split.ply", poly.get(), false);
   }
   {
-    std::auto_ptr<carve::mesh::MeshSet<3> > poly(
+    std::unique_ptr<carve::mesh::MeshSet<3> > poly(
         faceLoopsToPolyhedron(b_face_loops));
     writePLY("/tmp/b_split.ply", poly.get(), false);
   }
@@ -1499,9 +1499,9 @@ carve::mesh::MeshSet<3>* carve::csg::CSG::compute(
   size_t a_edge_count;
   size_t b_edge_count;
 
-  std::auto_ptr<face_rtree_t> a_rtree(
+  std::unique_ptr<face_rtree_t> a_rtree(
       face_rtree_t::construct_STR(a->faceBegin(), a->faceEnd(), 4, 4));
-  std::auto_ptr<face_rtree_t> b_rtree(
+  std::unique_ptr<face_rtree_t> b_rtree(
       face_rtree_t::construct_STR(b->faceBegin(), b->faceEnd(), 4, 4));
 
   {
@@ -1660,9 +1660,9 @@ bool carve::csg::CSG::sliceAndClassify(
   size_t a_edge_count;
   size_t b_edge_count;
 
-  std::auto_ptr<face_rtree_t> closed_rtree(face_rtree_t::construct_STR(
+  std::unique_ptr<face_rtree_t> closed_rtree(face_rtree_t::construct_STR(
       closed->faceBegin(), closed->faceEnd(), 4, 4));
-  std::auto_ptr<face_rtree_t> open_rtree(
+  std::unique_ptr<face_rtree_t> open_rtree(
       face_rtree_t::construct_STR(open->faceBegin(), open->faceEnd(), 4, 4));
 
   calc(closed, closed_rtree.get(), open, open_rtree.get(), vclass, eclass,
@@ -1724,9 +1724,9 @@ void carve::csg::CSG::slice(meshset_t* a, meshset_t* b,
   size_t a_edge_count;
   size_t b_edge_count;
 
-  std::auto_ptr<face_rtree_t> a_rtree(
+  std::unique_ptr<face_rtree_t> a_rtree(
       face_rtree_t::construct_STR(a->faceBegin(), a->faceEnd(), 4, 4));
-  std::auto_ptr<face_rtree_t> b_rtree(
+  std::unique_ptr<face_rtree_t> b_rtree(
       face_rtree_t::construct_STR(b->faceBegin(), b->faceEnd(), 4, 4));
 
   calc(a, a_rtree.get(), b, b_rtree.get(), vclass, eclass, a_face_loops,

--- a/lib/intersect_face_division.cpp
+++ b/lib/intersect_face_division.cpp
@@ -499,7 +499,7 @@ static void computeContainment(
     face_loops_sorted[m].reserve(f_loop.size());
     for (size_t n = 0; n < f_loop.size(); ++n) {
       face_loops_projected[m].push_back(face->project(f_loop[n]->v));
-      face_loops_sorted[m].push_back(n);
+      face_loops_sorted[m].push_back(static_cast<unsigned int>(n));
     }
     face_loop_areas.push_back(
         carve::geom2d::signedArea(face_loops_projected[m]));
@@ -519,7 +519,7 @@ static void computeContainment(
     hole_loops_projected[m].reserve(h_loop.size());
     for (size_t n = 0; n < h_loop.size(); ++n) {
       hole_loops_projected[m].push_back(face->project(h_loop[n]->v));
-      hole_loops_sorted[m].push_back(n);
+      hole_loops_sorted[m].push_back(static_cast<unsigned int>(n));
     }
     hole_loop_areas.push_back(
         carve::geom2d::signedArea(hole_loops_projected[m]));

--- a/lib/mesh.cpp
+++ b/lib/mesh.cpp
@@ -31,6 +31,7 @@
 #include <carve/rtree.hpp>
 
 #include <carve/poly.hpp>
+#include <functional>
 
 namespace {
 inline double CALC_X(const carve::geom::plane<3>& p, double y, double z) {
@@ -932,7 +933,7 @@ static void copyMeshFaces(
     ;
 
     poly->faces.push_back(poly::Polyhedron::face_t(vert_ptr));
-    poly->faces.back().manifold_id = manifold_id;
+    poly->faces.back().manifold_id = static_cast<int>(manifold_id);
     poly->faces.back().owner = poly;
   }
 }

--- a/lib/polyhedron.cpp
+++ b/lib/polyhedron.cpp
@@ -251,7 +251,7 @@ bool Polyhedron::initConnectivity() {
       for (size_t f = 0; f < mesh->faces.size(); ++f) {
         mesh::Face<3>* src = mesh->faces[f];
         mesh::Edge<3>* e = src->edge;
-        faces[face_map[src]].manifold_id = m;
+        faces[face_map[src]].manifold_id = static_cast<int>(m);
         do {
           edge_map[std::make_pair(e->v1() - Vbase, e->v2() - Vbase)].push_back(
               e);
@@ -360,7 +360,7 @@ bool Polyhedron::calcManifoldEmbedding() {
 
   carve::TimingBlock block(FUNC_NAME);
 
-  const unsigned MCOUNT = manifoldCount();
+  const size_t MCOUNT = manifoldCount();
   if (MCOUNT < 2) {
     return true;
   }
@@ -784,14 +784,14 @@ void Polyhedron::testVertexAgainstClosedManifolds(
     if (!manifold_is_closed[i]) {
       continue;
     }
-    if (result.find(i) != result.end()) {
+    if (result.find(static_cast<int>(i)) != result.end()) {
       continue;
     }
     PointClass pc = (crossings[i] & 1) ? POINT_IN : POINT_OUT;
     if (!ignore_orientation && manifold_is_negative[i]) {
       pc = (PointClass)-pc;
     }
-    result[i] = pc;
+    result[static_cast<int>(i)] = pc;
   }
 }
 

--- a/lib/polyline.cpp
+++ b/lib/polyline.cpp
@@ -58,7 +58,7 @@ void PolylineSet::sortVertices(const carve::geom3d::Vector& axis) {
 
   for (size_t i = 0; i < vertices.size(); ++i) {
     vnew.push_back(vertices[temp[i].second]);
-    revmap[temp[i].second] = i;
+    revmap[temp[i].second] = static_cast<int>(i);
   }
 
   for (line_iter i = lines.begin(); i != lines.end(); ++i) {

--- a/lib/shewchuk_predicates.cpp
+++ b/lib/shewchuk_predicates.cpp
@@ -116,7 +116,6 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
 
 /* On some machines, the exact arithmetic routines might be defeated by the  */
 /*   use of internal extended precision floating-point registers.  Sometimes */
@@ -519,9 +518,9 @@ double doublerand() {
   long a, b, c;
   long i;
 
-  a = random();
-  b = random();
-  c = random();
+  a = rand();
+  b = rand();
+  c = rand();
   result = (double)(a - 1073741824) * 8388608.0 + (double)(b >> 8);
   for (i = 512, expo = 2; i <= 131072; i *= 2, expo = expo * expo) {
     if (c & i) {
@@ -544,9 +543,9 @@ double narrowdoublerand() {
   long a, b, c;
   long i;
 
-  a = random();
-  b = random();
-  c = random();
+  a = rand();
+  b = rand();
+  c = rand();
   result = (double)(a - 1073741824) * 8388608.0 + (double)(b >> 8);
   for (i = 512, expo = 2; i <= 2048; i *= 2, expo = expo * expo) {
     if (c & i) {
@@ -566,8 +565,8 @@ double uniformdoublerand() {
   double result;
   long a, b;
 
-  a = random();
-  b = random();
+  a = rand();
+  b = rand();
   result = (double)(a - 1073741824) * 8388608.0 + (double)(b >> 8);
   return result;
 }

--- a/lib/triangle_intersection.cpp
+++ b/lib/triangle_intersection.cpp
@@ -35,6 +35,7 @@
 #include <cstdlib>
 
 #include <iostream>
+#include <algorithm>
 
 typedef carve::geom::vector<3> vec3;
 typedef carve::geom::vector<2> vec2;
@@ -139,6 +140,10 @@ bool sat_plane(const vec3 tri_a[3], const vec3 tri_b[3], unsigned i, unsigned j,
   return false;
 }
 
+inline bool sat_plane_size_t(const vec3 tri_a[3], const vec3 tri_b[3], size_t i, size_t j, size_t k) {
+   return sat_plane(tri_a, tri_b, static_cast<unsigned>(i), static_cast<unsigned>(j), static_cast<unsigned>(k));
+}
+
 // returns true if no intersection, based upon edge^a_i and vertex^b_j
 // separating plane.
 bool sat_plane(const vec3 tri_a[3], const vec3 tri_b[3], unsigned i,
@@ -165,6 +170,10 @@ bool sat_plane(const vec3 tri_a[3], const vec3 tri_b[3], unsigned i,
   return false;
 }
 
+inline bool sat_plane_size_t(const vec3 tri_a[3], const vec3 tri_b[3], size_t i, size_t j) {
+  return sat_plane(tri_a, tri_b, static_cast<unsigned>(i), static_cast<unsigned>(j));
+}
+
 // returns: -1 - no intersection
 //           0 - touching
 //          +1 - intersection
@@ -174,15 +183,24 @@ int sat_edge(const vec2 tri_a[3], const vec2 tri_b[3], unsigned i) {
               dbl_sign(orient2d_exact(tri_a[i], tri_a[(i + 1) % 3], tri_b[2])));
 }
 
+inline int sat_edge_size_t(const vec2 tri_a[3], const vec2 tri_b[3], size_t i) { 
+	return sat_edge(tri_a, tri_b, static_cast<unsigned>(i));
+}
+
+
 // returns: -1 - no intersection
 //           0 - touching
 //          +1 - intersection
-bool sat_edge(const vec2 tri_a[3], const vec2 tri_b[3], unsigned i,
+int sat_edge(const vec2 tri_a[3], const vec2 tri_b[3], unsigned i,
               unsigned j) {
   return std::max(dbl_sign(orient2d_exact(tri_a[i], tri_a[(i + 1) % 3],
                                           tri_b[(j + 1) % 3])),
                   dbl_sign(orient2d_exact(tri_a[i], tri_a[(i + 1) % 3],
                                           tri_b[(j + 2) % 3])));
+}
+
+inline int sat_edge_size_t(const vec2 tri_a[3], const vec2 tri_b[3], size_t i, size_t j) {
+   return sat_edge(tri_a, tri_b, static_cast<unsigned>(i), static_cast<unsigned>(j));
 }
 
 // test for vertex sharing. between a triangle pair.
@@ -445,16 +463,16 @@ TriangleInt triangle_intersection(const vec2 tri_a[3], const vec2 tri_b[3]) {
     }
     case 1: {
       // shared vertex (ia, ib) [but not shared edge]
-      if (sat_edge(tri_a, tri_b, (ia + 2) % 3, ib) < 0) {
+	  if (sat_edge_size_t(tri_a, tri_b, (ia + 2) % 3, ib) < 0) {
         return TR_INT_VERT;
       }
-      if (sat_edge(tri_a, tri_b, ia, ib) < 0) {
+	  if (sat_edge_size_t(tri_a, tri_b, ia, ib) < 0) {
         return TR_INT_VERT;
       }
-      if (sat_edge(tri_b, tri_a, (ib + 2) % 3, ia) < 0) {
+	  if (sat_edge_size_t(tri_b, tri_a, (ib + 2) % 3, ia) < 0) {
         return TR_INT_VERT;
       }
-      if (sat_edge(tri_b, tri_a, ib, ia) < 0) {
+	  if (sat_edge_size_t(tri_b, tri_a, ib, ia) < 0) {
         return TR_INT_VERT;
       }
 
@@ -513,10 +531,10 @@ TriangleInt triangle_intersection(const vec3 tri_a[3], const vec3 tri_b[3]) {
       // no shared vertices.
       for (size_t i = 0; i < 3; ++i) {
         for (size_t j = 0; j < 3; ++j) {
-          if (sat_plane(tri_a, tri_b, i, j)) {
+          if (sat_plane_size_t(tri_a, tri_b, i, j)) {
             return TR_INT_NONE;
           }
-          if (sat_plane(tri_b, tri_a, i, j)) {
+		  if (sat_plane_size_t(tri_b, tri_a, i, j)) {
             return TR_INT_NONE;
           }
         }
@@ -529,28 +547,28 @@ TriangleInt triangle_intersection(const vec3 tri_a[3], const vec3 tri_b[3]) {
       size_t ia0 = ia, ia1 = (ia + 1) % 3, ia2 = (ia + 2) % 3;
       size_t ib0 = ib, ib1 = (ib + 1) % 3, ib2 = (ib + 2) % 3;
 
-      if (sat_plane(tri_a, tri_b, ia2, ib1, ib2)) {
+	  if (sat_plane_size_t(tri_a, tri_b, ia2, ib1, ib2)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_a, tri_b, ia2, ib2, ib1)) {
+	  if (sat_plane_size_t(tri_a, tri_b, ia2, ib2, ib1)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_a, tri_b, ia0, ib1, ib2)) {
+	  if (sat_plane_size_t(tri_a, tri_b, ia0, ib1, ib2)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_a, tri_b, ia0, ib2, ib1)) {
+	  if (sat_plane_size_t(tri_a, tri_b, ia0, ib2, ib1)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_b, tri_b, ib2, ia1, ia2)) {
+	  if (sat_plane_size_t(tri_b, tri_b, ib2, ia1, ia2)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_b, tri_b, ib2, ia2, ia1)) {
+	  if (sat_plane_size_t(tri_b, tri_b, ib2, ia2, ia1)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_b, tri_b, ib0, ia1, ia2)) {
+	  if (sat_plane_size_t(tri_b, tri_b, ib0, ia1, ia2)) {
         return TR_INT_VERT;
       }
-      if (sat_plane(tri_b, tri_b, ib0, ia2, ia1)) {
+	  if (sat_plane_size_t(tri_b, tri_b, ib0, ia2, ia1)) {
         return TR_INT_VERT;
       }
 
@@ -573,12 +591,12 @@ bool triangle_intersection_simple(const vec2 tri_a[3], const vec2 tri_b[3]) {
   CARVE_ASSERT(orient2d_exact(tri_b[0], tri_b[1], tri_b[2]) >= 0.0);
 
   for (size_t i = 0; i < 3; ++i) {
-    if (sat_edge(tri_a, tri_b, i) < 0) {
+	  if (sat_edge_size_t(tri_a, tri_b, i) < 0) {
       return false;
     }
   }
   for (size_t i = 0; i < 3; ++i) {
-    if (sat_edge(tri_b, tri_a, i) < 0) {
+	  if (sat_edge_size_t(tri_b, tri_a, i) < 0) {
       return false;
     }
   }
@@ -605,10 +623,10 @@ bool triangle_intersection_simple(const vec3 tri_a[3], const vec3 tri_b[3]) {
 
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = 0; j < 3; ++j) {
-      if (sat_plane(tri_a, tri_b, i, j)) {
+      if (sat_plane_size_t(tri_a, tri_b, i, j)) {
         return false;
       }
-      if (sat_plane(tri_b, tri_a, i, j)) {
+	  if (sat_plane_size_t(tri_b, tri_a, i, j)) {
         return false;
       }
     }
@@ -675,10 +693,10 @@ TriangleIntType triangle_intersection_exact(const vec2 tri_a[3],
 
   int curr = +1;
   for (size_t i = 0; curr != -1 && i < 3; ++i) {
-    curr = std::min(curr, sat_edge(tri_a, tri_b, i));
+    curr = std::min(curr, sat_edge_size_t(tri_a, tri_b, i));
   }
   for (size_t i = 0; curr != -1 && i < 3; ++i) {
-    curr = std::min(curr, sat_edge(tri_b, tri_a, i));
+	  curr = std::min(curr, sat_edge_size_t(tri_b, tri_a, i));
   }
   switch (curr) {
     case -1:

--- a/lib/triangulator.cpp
+++ b/lib/triangulator.cpp
@@ -556,8 +556,9 @@ size_t carve::triangulate::detail::removeDegeneracies(
     }
 
     if (remove) {
-      result.push_back(carve::triangulate::tri_idx(v->idx, v->next->idx,
-                                                   v->next->next->idx));
+      result.push_back(carve::triangulate::tri_idx(static_cast<unsigned int>(v->idx), 
+                                                   static_cast<unsigned int>(v->next->idx),
+                                                   static_cast<unsigned int>(v->next->next->idx)));
       n = v->next;
       if (n == begin) {
         begin = n->next;
@@ -659,7 +660,9 @@ bool carve::triangulate::detail::doTriangulate(
     vertex_info* p = v->prev;
 
     result.push_back(
-        carve::triangulate::tri_idx(v->prev->idx, v->idx, v->next->idx));
+        carve::triangulate::tri_idx(static_cast<unsigned int>(v->prev->idx),
+                                    static_cast<unsigned int>(v->idx),
+                                    static_cast<unsigned int>(v->next->idx)));
 
 #if defined(CARVE_DEBUG)
     {
@@ -734,8 +737,9 @@ bool carve::triangulate::detail::doTriangulate(
   }
 
   if (remain == 3) {
-    result.push_back(carve::triangulate::tri_idx(begin->idx, begin->next->idx,
-                                                 begin->next->next->idx));
+	  result.push_back(carve::triangulate::tri_idx(static_cast<unsigned int>(begin->idx),
+                                                   static_cast<unsigned int>(begin->next->idx),
+                                                   static_cast<unsigned int>(begin->next->next->idx)));
   }
 
   vertex_info* d = begin;

--- a/src/close_manifold.cpp
+++ b/src/close_manifold.cpp
@@ -129,7 +129,7 @@ static bool endswith(const std::string& a, const std::string& b) {
     return false;
   }
 
-  for (unsigned i = a.size(), j = b.size(); j;) {
+  for (size_t i = a.size(), j = b.size(); j;) {
     if (tolower(a[--i]) != tolower(b[--j])) {
       return false;
     }

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -120,7 +120,7 @@ static bool endswith(const std::string& a, const std::string& b) {
     return false;
   }
 
-  for (unsigned i = a.size(), j = b.size(); j;) {
+  for (size_t i = a.size(), j = b.size(); j;) {
     if (tolower(a[--i]) != tolower(b[--j])) {
       return false;
     }

--- a/src/cut.cpp
+++ b/src/cut.cpp
@@ -106,7 +106,7 @@ static bool endswith(const std::string& a, const std::string& b) {
     return false;
   }
 
-  for (unsigned i = a.size(), j = b.size(); j;) {
+  for (size_t i = a.size(), j = b.size(); j;) {
     if (tolower(a[--i]) != tolower(b[--j])) {
       return false;
     }

--- a/src/extrude.cpp
+++ b/src/extrude.cpp
@@ -397,7 +397,7 @@ carve::poly::Polyhedron* extrude(
 
   for (size_t p = 0; p < paths.size(); ++p) {
     const std::vector<carve::geom2d::P2>& path = paths[p];
-    const unsigned N = path.size();
+    const size_t N = path.size();
     std::cerr << "N=" << N << std::endl;
 
     std::vector<unsigned> fwd, rev;
@@ -415,18 +415,18 @@ carve::poly::Polyhedron* extrude(
       j = vert_idx.find(v);
       if (j == vert_idx.end()) {
         data.addVertex(v);
-        fwd.push_back(vert_idx[v] = data.getVertexCount() - 1);
+        fwd.push_back(static_cast<unsigned>(vert_idx[v] = data.getVertexCount() - 1));
       } else {
-        fwd.push_back((*j).second);
+        fwd.push_back(static_cast<unsigned>((*j).second));
       }
 
       v = carve::geom::VECTOR(path[i].x, -path[i].y, 0.0) + dir;
       j = vert_idx.find(v);
       if (j == vert_idx.end()) {
         data.addVertex(v);
-        rev.push_back(vert_idx[v] = data.getVertexCount() - 1);
+        rev.push_back(static_cast<unsigned int>(vert_idx[v] = data.getVertexCount() - 1));
       } else {
-        rev.push_back((*j).second);
+        rev.push_back(static_cast<unsigned int>((*j).second));
       }
     }
 

--- a/src/face_merge.cpp
+++ b/src/face_merge.cpp
@@ -47,7 +47,6 @@
 #include <string>
 #include <utility>
 
-#include <sys/time.h>
 #include <time.h>
 
 typedef carve::mesh::MeshSet<3> meshset_t;

--- a/src/intersect.cpp
+++ b/src/intersect.cpp
@@ -267,7 +267,7 @@ static bool endswith(const std::string& a, const std::string& b) {
     return false;
   }
 
-  for (unsigned i = a.size(), j = b.size(); j;) {
+  for (size_t i = a.size(), j = b.size(); j;) {
     if (tolower(a[--i]) != tolower(b[--j])) {
       return false;
     }

--- a/src/selfintersect.cpp
+++ b/src/selfintersect.cpp
@@ -109,7 +109,7 @@ static bool endswith(const std::string& a, const std::string& b) {
     return false;
   }
 
-  for (unsigned i = a.size(), j = b.size(); j;) {
+  for (size_t i = a.size(), j = b.size(); j;) {
     if (tolower(a[--i]) != tolower(b[--j])) {
       return false;
     }
@@ -259,8 +259,8 @@ int triangle_line_intersection_2d(const vec3 tri[3], const vec3& p1,
   pp1 = carve::geom::select(p1, a1, a2);
   pp2 = carve::geom::select(p2, a1, a2);
 
-  int ia = std::find(ptri, ptri + 3, pp1) - ptri;
-  int ib = std::find(ptri, ptri + 3, pp2) - ptri;
+  int ia = static_cast<int>(std::find(ptri, ptri + 3, pp1) - ptri);
+  int ib = static_cast<int>(std::find(ptri, ptri + 3, pp2) - ptri);
 
   if (ia == 3 && ib == 3) {
     // no shared vertices
@@ -350,9 +350,9 @@ int triangle_triangle_intersection_2d(const vec3 tri_a[3],
     std::swap(ptri_b[0], ptri_b[2]);
   }
 
-  int ia = std::find(ptri_b, ptri_b + 3, ptri_a[0]) - ptri_b;
-  int ib = std::find(ptri_b, ptri_b + 3, ptri_a[1]) - ptri_b;
-  int ic = std::find(ptri_b, ptri_b + 3, ptri_a[2]) - ptri_b;
+  int ia = static_cast<int>(std::find(ptri_b, ptri_b + 3, ptri_a[0]) - ptri_b);
+  int ib = static_cast<int>(std::find(ptri_b, ptri_b + 3, ptri_a[1]) - ptri_b);
+  int ic = static_cast<int>(std::find(ptri_b, ptri_b + 3, ptri_a[2]) - ptri_b);
 
   if (ia == 3 && ib == 3 && ic == 3) {
     // no shared vertices
@@ -569,10 +569,10 @@ int orient3d_inexact(const vec3& a, const vec3& b, const vec3& c,
   double errbound = 0.0;  // shewchuk::robust.o3derrboundA * permanent;
 
   if ((det > errbound) || (-det > errbound)) {
-    return det;
+    return static_cast<int>(det);
   }
 
-  return 0.0;
+  return 0;
 }
 
 // returns true if no intersection, based upon normal testing.
@@ -591,7 +591,9 @@ bool sat_normal(const vec3 tri_a[3], const vec3 tri_b[3]) {
 // returns true if no intersection, based upon edge^a_i and edge^b_j separating
 // axis.
 bool sat_edge(const vec3 tri_a[3], const vec3 tri_b[3], unsigned i,
-              unsigned j) {}
+	unsigned j) {
+	return false;
+}
 
 // 0 = not intersecting
 // 1 = shared vertex

--- a/src/triangulate.cpp
+++ b/src/triangulate.cpp
@@ -122,7 +122,7 @@ static bool endswith(const std::string& a, const std::string& b) {
     return false;
   }
 
-  for (unsigned i = a.size(), j = b.size(); j;) {
+  for (size_t i = a.size(), j = b.size(); j;) {
     if (tolower(a[--i]) != tolower(b[--j])) {
       return false;
     }

--- a/tests/mersenne_twister.h
+++ b/tests/mersenne_twister.h
@@ -65,10 +65,20 @@
 #include <time.h>
 #include <math.h>
 
-#if !defined(_WIN32)
-#include <stdint.h>
-#else
+#if defined(WIN32) && defined(_MSC_VER) && _MSC_VER < 1800
+
+typedef char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
 typedef unsigned long uint32_t;
+
+#else 
+
+#include <stdint.h>
+
 #endif
 
 class MTRand {


### PR DESCRIPTION
Hi, thanks for the great library, now used in https://github.com/arnholm/xcsg
These updates to make carve compatible with MSVC2013 and also g++ 7.3.0 under Ubuntu 18.04

- correct many integer sign warnings using static_cast<> and more
- replaced deprecated use of auto_ptr with unique_ptr instead
- added several missing standard headers

carve now compiler under MSVC2013 and g++ 7.3.0 on linux with few or no warnings. The changes to carve have been tested using xcsg (several examples), no issues.
